### PR TITLE
Adding handling for both 1.0 and 1.1 transaction values

### DIFF
--- a/templates.js
+++ b/templates.js
@@ -10766,6 +10766,9 @@ output += "</td>\n\t\t\t\t\t\t\t<td>";
 output += runtime.suppressValue(env.getFilter("currency").call(context, runtime.memberLookup((runtime.memberLookup((t_4),"amount")),"amount")), env.opts.autoescape);
 output += " ";
 output += runtime.suppressValue(runtime.memberLookup((runtime.memberLookup((t_4),"amount")),"currency"), env.opts.autoescape);
+output += runtime.suppressValue(env.getFilter("currency").call(context, runtime.memberLookup((runtime.memberLookup((t_4),"value")),"amount")), env.opts.autoescape);
+output += " ";
+output += runtime.suppressValue(runtime.memberLookup((runtime.memberLookup((t_4),"value")),"currency"), env.opts.autoescape);
 output += "</td>\n\n              <td>\n\n                ";
 if(runtime.memberLookup((runtime.memberLookup((t_4),"payee")),"id") && runtime.memberLookup((runtime.contextOrFrameLookup(context, frame, "parties")),runtime.memberLookup((runtime.memberLookup((t_4),"payee")),"id"))) {
 output += "\n                <a data-toggle=\"modal\" href=\"#organization-";

--- a/templates/transactions.html
+++ b/templates/transactions.html
@@ -23,7 +23,7 @@
 						<tr>
 							<td>{{ transaction.id }}</td>
 							<td>{{ date_popout(transaction, 'date') }}</td>
-							<td>{{ transaction.amount.amount|currency }} {{ transaction.amount.currency }}</td>
+							<td>{{ transaction.amount.amount|currency }} {{ transaction.amount.currency }}{{ transaction.value.amount|currency }} {{ transaction.value.currency }}</td>
 
               <td>
 


### PR DESCRIPTION
In OCDS 1.1 we deprecated `transaction.amount` in favour of `transaction.value` for consistency with other uses of `value`.

I realised OCDS show was only checking for `transaction.amount`, so I've added in template tags to display value instead if these are available, whilst leaving amount there for cases where we are dealing with 1.0 data. 

